### PR TITLE
Full Karlsen Network Support

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 ISC License
 
+Copyright (c) 2023 The Karlsen developers
 Copyright (c) 2019 The kaspanet developers
 Copyright (c) 2018 The Decred developers
 

--- a/README.md
+++ b/README.md
@@ -1,29 +1,30 @@
-DNSSeeder
-====
-This project is currently under active development and is in Beta state.
-====
+# DNSSeeder
+
+**This project is currently under active development and is in Beta
+state.**
 
 [![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](https://choosealicense.com/licenses/isc/)
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/kaspanet/dnsseeder)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/karlsen-network/dnsseeder)
 
-DNSSeeder exposes a list of known peers to any new peer joining the Kaspa network via the DNS protocol.
+DNSSeeder exposes a list of known peers to any new peer joining the
+Karlsen network via the DNS protocol.
 
-When DNSSeeder is started for the first time, it will connect to the kaspad node
-specified with the `-s` flag and listen for `addr` messages. These messages
-contain the IPs of all peers known by the node. DNSSeeder will then connect to
-each of these peers, listen for their `addr` messages, and continue to traverse
-the network in this fashion. DNSSeeder maintains a list of all known peers and
-periodically checks that they are online and available. The list is stored on
-disk in a json file, so on subsequent start ups the kaspad node specified with
-`-s` does not need to be online.
+When DNSSeeder is started for the first time, it will connect to the
+`karlsend` node specified with the `-s` flag and listen for `addr`
+messages. These messages contain the IPs of all peers known by the node.
+DNSSeeder will then connect to each of these peers, listen for their
+`addr` messages, and continue to traverse the network in this fashion.
+DNSSeeder maintains a list of all known peers and periodically checks
+that they are online and available. The list is stored on disk in a json
+file, so on subsequent start ups the `karlsend` node specified with `-s`
+does not need to be online.
 
-When DNSSeeder is queried for node information, it responds with details of a
-random selection of the reliable nodes it knows about.
+When DNSSeeder is queried for node information, it responds with details
+of a random selection of the reliable nodes it knows about.
 
 It is written in Go (golang).
 
 This project is currently under active development and is in Beta state.
-
 
 ## Requirements
 
@@ -31,52 +32,56 @@ Latest version of [Go](http://golang.org) (currently 1.17)
 
 ## Getting Started
 
-- Install Go according to the installation instructions here:
+* Install Go according to the installation instructions here:
   http://golang.org/doc/install
 
-- Ensure Go was installed properly and is a supported version:
+* Ensure Go was installed properly and is a supported version:
 
-- Launch a kaspad node for the DNSSeeder to connect to
+* Launch a `karlsend` node for the DNSSeeder to connect to
 
 ```bash
-$ go version
-$ go env GOROOT GOPATH
+go version
+go env GOROOT GOPATH
 ```
 
 NOTE: The `GOROOT` and `GOPATH` above must not be the same path. It is
-recommended that `GOPATH` is set to a directory in your home directory such as
-`~/dev/go` to avoid write permission issues. It is also recommended to add
-`$GOPATH/bin` to your `PATH` at this point.
+recommended that `GOPATH` is set to a directory in your home directory
+such as `~/dev/go` to avoid write permission issues. It is also
+recommended to add `${GOPATH}/bin` to your `PATH` at this point.
 
-- Run the following commands to obtain dnsseeder, all dependencies, and install it:
+- Run the following commands to obtain dnsseeder, all dependencies, and
+install it:
 
 ```bash
-$ git clone https://github.com/kaspanet/dnsseeder $GOPATH/src/github.com/kaspanet/dnsseeder
-$ cd $GOPATH/src/github.com/kaspanet/dnsseeder
-$ go install . 
+git clone https://github.com/karlsen-network/dnsseeder ${GOPATH}/src/github.com/karlsen-network/dnsseeder
+cd ${GOPATH}/src/github.com/karlsen-network/dnsseeder
+go install .
 ```
 
-- dnsseeder will now be installed in either ```$GOROOT/bin``` or
-  ```$GOPATH/bin``` depending on your configuration. If you did not already
-  add the bin directory to your system path during Go installation, we
-  recommend you do so now.
+* dnsseeder will now be installed in either ```${GOROOT}/bin``` or
+  ```${GOPATH}/bin``` depending on your configuration. If you did not
+  already add the bin directory to your system path during Go
+  installation, we recommend you do so now.
 
-To start dnsseeder listening on udp 127.0.0.1:5354 with an initial connection to working testnet node running on 127.0.0.1:
+To start dnsseeder listening on udp `127.0.0.1:5354` with an initial
+connection to working testnet node running on `127.0.0.1`:
 
 ```
-$ ./dnsseeder -n nameserver.example.com -H network-seed.example.com -s 127.0.0.1 --testnet
+./dnsseeder -n nameserver.example.com -H network-seed.example.com -s 127.0.0.1 --testnet
 ```
 
-You will then need to redirect DNS traffic on your public IP port 53 to 127.0.0.1:5354
-Note: to listen directly on port 53 on most Unix systems, one has to run dnsseeder as root, which is discouraged
+You will then need to redirect DNS traffic on your public IP port 53
+to `127.0.0.1:5354` Note: to listen directly on port 53 on most Unix
+systems, one has to run dnsseeder as root, which is discouraged.
 
 ## Setting up DNS Records
 
-To create a working set-up where the DNSSeeder can provide IPs to kaspad instances, set the following DNS records:
+To create a working set-up where the DNSSeeder can provide IPs to
+`karlsend` instances, set the following DNS records:
+
 ```
 NAME                        TYPE        VALUE
 ----                        ----        -----
 [your.domain.name]          A           [your ip address]
 [ns-your.domain.name]       NS          [your.domain.name]
 ```
-

--- a/config.go
+++ b/config.go
@@ -55,7 +55,6 @@ type ConfigFlags struct {
 	Seeder      string `short:"s" long:"default-seeder" description:"IP address of a working node, optionally with a port specifier"`
 	Profile     string `long:"profile" description:"Enable HTTP profiling on given port -- NOTE port must be between 1024 and 65536"`
 	GRPCListen  string `long:"grpclisten" description:"Listen gRPC requests on address:port"`
-	NetSuffix   uint16 `long:"netsuffix" description:"Testnet network suffix number"`
 	NoLogFiles  bool   `long:"nologfiles" description:"Disable logging to file"`
 	LogLevel    string `long:"loglevel" description:"Loglevel for stdout (console). Default: info"`
 	config.NetworkFlags
@@ -170,19 +169,6 @@ func loadConfig() (*ConfigFlags, error) {
 	err = activeConfig.ResolveNetwork(parser)
 	if err != nil {
 		return nil, err
-	}
-
-	// Manually enforce testnet 11 net params so we do not have to 
-	// support this special network in kaspad.
-	if activeConfig.NetSuffix != 0 {
-		if !activeConfig.Testnet {
-			return nil, errors.New("The net suffix can only be used with testnet")
-		}
-		if activeConfig.NetSuffix != 11 {
-			return nil, errors.New("The only supported explicit testnet net suffix is 11")
-		}
-		activeConfig.NetParams().DefaultPort = "16311";
-		activeConfig.NetParams().Name = "kaspa-testnet-11";
 	}
 
 	activeConfig.AppDir = cleanAndExpandPath(activeConfig.AppDir)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,23 +1,23 @@
 # -- multistage docker build: stage #1: build stage
 FROM golang:1.18-alpine AS build
 
-RUN mkdir -p /go/src/github.com/kaspanet/dnsseeder
+RUN mkdir -p /go/src/github.com/karlsen-network/dnsseeder
 
-WORKDIR /go/src/github.com/kaspanet/dnsseeder
+WORKDIR /go/src/github.com/karlsen-network/dnsseeder
 
 RUN apk add --no-cache curl git openssh binutils gcc musl-dev
 
 COPY go.mod .
 COPY go.sum .
 
-# For development it's useful to have kaspad from filesystem, but for deployment
+# For development it's useful to have karlsend from filesystem, but for deployment
 # we should use the one in github
-RUN go mod edit -dropreplace github.com/kaspanet/kaspad
-ARG KASPAD_VERSION
-ARG KASPAD_REPOSITORY='github.com/kaspanet/kaspad'
-RUN if [ -n "${KASPAD_VERSION}" ]; then \
+RUN go mod edit -dropreplace github.com/karlsen-network/karlsend
+ARG KARLSEND_VERSION
+ARG KARLSEND_REPOSITORY='github.com/karlsen-network/karlsend'
+RUN if [ -n "${KARLSEND_VERSION}" ]; then \
         # use replace instead of require - to propagate into nested dependancies \
-        go mod edit -replace "github.com/kaspanet/kaspad=$KASPAD_REPOSITORY@$KASPAD_VERSION"; \
+        go mod edit -replace "github.com/karlsen-network/karlsend=$KARLSEND_REPOSITORY@$KARLSEND_VERSION"; \
     fi
 
 RUN go mod download
@@ -41,7 +41,7 @@ WORKDIR /app
 
 RUN apk add --no-cache tini
 
-COPY --from=build /go/src/github.com/kaspanet/dnsseeder/ /app/
+COPY --from=build /go/src/github.com/karlsen-network/dnsseeder/ /app/
 
 ENTRYPOINT ["/sbin/tini", "--"]
 CMD ["/app/dnsseeder"]

--- a/manager.go
+++ b/manager.go
@@ -20,7 +20,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Node repesents a node in the Kaspa network
+// Node repesents a node in the Karlsen network
 type Node struct {
 	Addr         *appmessage.NetAddress
 	LastAttempt  time.Time

--- a/version/version.go
+++ b/version/version.go
@@ -15,7 +15,7 @@ const (
 )
 
 // appBuild is defined as a variable so it can be overridden during the build
-// process with '-ldflags "-X github.com/kaspanet/dnsseeder/version.appBuild=foo"' if needed.
+// process with '-ldflags "-X github.com/karlsen-network/dnsseeder/version.appBuild=foo"' if needed.
 // It MUST only contain characters from validCharacters.
 var appBuild string
 

--- a/version/version.go
+++ b/version/version.go
@@ -9,9 +9,9 @@ import (
 const validCharacters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-"
 
 const (
-	appMajor uint = 0
-	appMinor uint = 12
-	appPatch uint = 7
+	appMajor uint = 1
+	appMinor uint = 0
+	appPatch uint = 0
 )
 
 // appBuild is defined as a variable so it can be overridden during the build


### PR DESCRIPTION
This pull request focuses on refining Karlsen Network support within the DNSSeeder. Although the previous version already included support for Karlsen, it also contained modifications specific to Kaspa. Noteworthy changes include:

* Inclusion of copyright notice from Karlsen developers while preserving the original ones.
* Version bump to synchronize DNSseeder version with the `karlsend` node version `v1.0.0`.
* Removal of support for `testnet-11` since the 10 BPS testnet is not yet available. We plan to introduce it later for algorithm changes and smart contract (SC) implementation.